### PR TITLE
Check for null key after getInstanceKey

### DIFF
--- a/src/Propel/Runtime/ActiveQuery/InstancePoolTrait.php
+++ b/src/Propel/Runtime/ActiveQuery/InstancePoolTrait.php
@@ -23,7 +23,9 @@ trait InstancePoolTrait
                 $key = static::getInstanceKey($object);
             }
 
-            self::$instances[$key] = $object;
+            if (null !== $key) {
+                self::$instances[$key] = $object;
+            }
         }
     }
 


### PR DESCRIPTION
Sometimes getInstanceKey returns null (I think it's related to joinWith) and when the instance is saved to pool with null key, it will mess up the instance pool when acquiring the next row.